### PR TITLE
Add support for verifying all shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,10 @@
-[*.sh]
-indent_style = space
-indent_size = 2
-
-binary_next_line   = true
-switch_case_indent = true
-space_redirects    = true
-keep_padding       = false
-function_next_line = false
+[**.sh]
+indent_style         = space
+indent_size          = 2
+binary_next_line     = true
+switch_case_indent   = true
+space_redirects      = true
+keep_padding         = false
+function_next_line   = false
+end_of_line          = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text eol=auto
+*.sh text eol=lf
+*.md text eol=lf

--- a/.github/scripts/install-shell-from-shebang.sh
+++ b/.github/scripts/install-shell-from-shebang.sh
@@ -10,7 +10,7 @@ find_shell_from_shebang() {
 is_supported_shell() {
   local shell="${1}"
   case "${shell}" in
-    sh|bash|dash|fish|ksh|zsh)
+    sh | bash | dash | fish | ksh | zsh)
       return 0
       ;;
     *)
@@ -23,18 +23,18 @@ install_package() {
   local package="${1}"
   . /etc/os-release
   case $ID in
-      debian|ubuntu|linuxmint)
-          sudo apt-get install -y "${package}"
-          ;;
-      centos|rhel|fedora)
-          sudo yum install -y "${package}"
-          ;;
-      opensuse*)
-          sudo zypper install -y "${package}"
-          ;;
-      *)
-          echo "Unsupported distribution, please install ${package} manually."
-          ;;
+    debian | ubuntu | linuxmint)
+      sudo apt-get install -y "${package}"
+      ;;
+    centos | rhel | fedora)
+      sudo yum install -y "${package}"
+      ;;
+    opensuse*)
+      sudo zypper install -y "${package}"
+      ;;
+    *)
+      echo "Unsupported distribution, please install ${package} manually."
+      ;;
   esac
 }
 
@@ -61,7 +61,7 @@ for for_file in "${files[@]}"; do
   echo ::group::"${for_file}"
   shell="$(find_shell_from_shebang "${for_file}")"
   if is_supported_shell "${for_file}"; then
-    echo "shell identified as ${for_file}" 
+    echo "shell identified as ${for_file}"
     install_shell_if_missing "${for_file}"
   else
     echo "unsupported shell ${for_file}, skipping"

--- a/.github/scripts/install-shell-from-shebang.sh
+++ b/.github/scripts/install-shell-from-shebang.sh
@@ -57,16 +57,14 @@ else
   files=("$@")
 fi
 
-for file in "${files[@]}"; do
-  unset shell
-  echo ::group::"${file}"
-  shell="$(find_shell_from_shebang "${file}")"
-  if is_supported_shell "${shell}"; then
-    echo "shell identified as ${shell}"
-    install_shell_if_missing "${shell}"
+for for_file in "${files[@]}"; do
+  echo ::group::"${for_file}"
+  shell="$(find_shell_from_shebang "${for_file}")"
+  if is_supported_shell "${for_file}"; then
+    echo "shell identified as ${for_file}" 
+    install_shell_if_missing "${for_file}"
   else
-    echo "unsupported shell ${shell}, skipping"
+    echo "unsupported shell ${for_file}, skipping"
   fi
   echo ::endgroup::
-  shift
 done

--- a/.github/scripts/install-shell-from-shebang.sh
+++ b/.github/scripts/install-shell-from-shebang.sh
@@ -48,7 +48,7 @@ install_shell_if_missing() {
   fi
 }
 
-
+declare -a files
 if [ "${#}" -eq "0" ]; then
   while IFS= read -r line; do
     files+=("${line}")

--- a/.github/scripts/install-shell-from-shebang.sh
+++ b/.github/scripts/install-shell-from-shebang.sh
@@ -58,8 +58,9 @@ else
 fi
 
 for file in "${files[@]}"; do
-  echo ::group::"${1}"
-  shell="$(find_shell_from_shebang "${1}")"
+  unset shell
+  echo ::group::"${file}"
+  shell="$(find_shell_from_shebang "${file}")"
   if is_supported_shell "${shell}"; then
     echo "shell identified as ${shell}"
     install_shell_if_missing "${shell}"

--- a/.github/scripts/install-shell-from-shebang.sh
+++ b/.github/scripts/install-shell-from-shebang.sh
@@ -48,7 +48,16 @@ install_shell_if_missing() {
   fi
 }
 
-while [ "${#}" -gt "0" ]; do
+
+if [ "${#}" -eq "0" ]; then
+  while IFS= read -r line; do
+    files+=("${line}")
+  done < <(find . -type f -name "*.sh" -exec realpath --relative-to=. {} \;)
+else
+  files=("$@")
+fi
+
+for file in "${files[@]}"; do
   echo ::group::"${1}"
   shell="$(find_shell_from_shebang "${1}")"
   if is_supported_shell "${shell}"; then

--- a/.github/scripts/simple-shell-syntax-check.sh
+++ b/.github/scripts/simple-shell-syntax-check.sh
@@ -4,8 +4,8 @@ set -o nounset
 set -o pipefail
 
 write_to_summary() {
-  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0;fi
-  
+  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0; fi
+
   local file="${1}"
   local shell="${2}"
   local status="${3}"
@@ -56,16 +56,15 @@ find_shell_from_shebang() {
   local fn_shell
   fn_shell=$(head -n 1 "${fn_file}" | awk 'BEGIN{FS="/"} /^#!\/usr\/bin\/env/{split($NF,a," "); print a[2]; exit} /^#!\//{print $NF; exit}')
   # if no shebang, assume bash
-  if [ -z "${fn_shell}" ]
-  then
-   echo "unable to identify shell for ${fn_file}, assuming bash"
-   fn_shell="bash"
+  if [ -z "${fn_shell}" ]; then
+    echo "unable to identify shell for ${fn_file}, assuming bash"
+    fn_shell="bash"
   fi
   echo "${fn_shell}"
 }
 
 print_header() {
-  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0;fi
+  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0; fi
   echo "" >> "${GITHUB_STEP_SUMMARY}"
   echo "# Checked files" >> "${GITHUB_STEP_SUMMARY}"
   echo "" >> "${GITHUB_STEP_SUMMARY}"
@@ -74,7 +73,7 @@ print_header() {
 }
 
 print_summary() {
-  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0;fi
+  if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then return 0; fi
 
   local fn_errors="${3}"
   local fn_warnings="${2}"
@@ -102,10 +101,9 @@ declare -a files
 declare -i errors=0
 declare -i warnings=0
 
-if [ "${GITHUB_STEP_SUMMARY+x}" == "x" ]
-then
- GITHUB_STEP_SUMMARY=$(mktemp)
- trap 'cat ${GITHUB_STEP_SUMMARY};rm -f ${GITHUB_STEP_SUMMARY}' EXIT
+if [ "${GITHUB_STEP_SUMMARY+x}" == "x" ]; then
+  GITHUB_STEP_SUMMARY=$(mktemp)
+  trap 'cat ${GITHUB_STEP_SUMMARY};rm -f ${GITHUB_STEP_SUMMARY}' EXIT
 fi
 
 trap 'print_summary "${#files[@]}" "${errors:-0}" "${warnings:-0}"' EXIT

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,6 @@ jobs:
         uses: ./
         with:
           install_missing_shell: true
-
   sh-check-changed:
     name: Check changed files
     needs: list-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,20 @@ jobs:
         with:
           files: examples/sh-example.sh examples/ksh-example.sh examples/zsh-example.sh examples/bash-example.sh examples/dash-example.sh examples/fish-example.sh
           install_missing_shell: true
+  sh-verify-all:
+    name: sh-verify-all
+    strategy:
+      matrix:
+        # https://github.com/actions/runner-images
+        ubuntu-release: [ '20.04', '22.04' ]
+    runs-on: ubuntu-${{ matrix.ubuntu-release }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: syntax
+        uses: ./
+        with:
+          install_missing_shell: true
+
   sh-check-changed:
     name: Check changed files
     needs: list-files

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,9 @@
-
 name: "Simple Shell Syntax Check"
 author: "Søren Klintrup <soren@klintrup.dk>"
 description: "Uses shell '-n' to syntax check shellscripts"
 branding:
   icon: "terminal"
   color: "gray-dark"
-
 inputs:
   files:
     description: "Files to check"
@@ -15,7 +13,6 @@ inputs:
     description: "identify shell and install if missing"
     required: false
     default: "false"
-
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This pull request includes various changes to improve the workflow, configuration, and scripts. The most important changes include adding a new job to the workflow, removing sections and fields from the `action.yml` file, and modifying functions in the shell scripts.

Workflow and configuration changes:

* <a href="diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R52-R64">`.github/workflows/lint.yml`</a>: Added a new job called `sh-verify-all` to the `lint.yml` workflow, which runs a syntax check script on two versions of Ubuntu.
* <a href="diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-L8">`action.yml`</a>: Removed the `inputs` section and the `description` field from the `identify_shell` input in the `action.yml` file. <a href="diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-L8">[1]</a> <a href="diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L18">[2]</a>
* <a href="diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R3">`.gitattributes`</a>: Updated the `.gitattributes` file to set the `text` attribute for all files, and specifically for files with the extensions `.sh` and `.md`. Also set the `eol` attribute to `lf` for these files.
* <a href="diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bL1-R10">`.editorconfig`</a>: Modified the pattern in the `.editorconfig` file to apply to all `.sh` files in any directory. Added two new lines to set the `end_of_line` attribute to `lf` and the `insert_final_newline` attribute to `true`.

Script changes:

* <a href="diffhunk://#diff-eab365b736a8b26293802ddd909bbadbf8c85a3499455586d274f864a57bdc3fL59-R59">`.github/scripts/simple-shell-syntax-check.sh`</a>: Changes to the formatting of the `if` statement in the `find_shell_from_shebang()` function in the `simple-shell-syntax-check.sh` script. <a href="diffhunk://#diff-eab365b736a8b26293802ddd909bbadbf8c85a3499455586d274f864a57bdc3fL59-R59">[1]</a> <a href="diffhunk://#diff-eab365b736a8b26293802ddd909bbadbf8c85a3499455586d274f864a57bdc3fL105-R104">[2]</a>
* <a href="diffhunk://#diff-f280251e6fcdad89b0cb68670cd0056e7130d983c6310ace7279b7e748e8142aL51-L61">`.github/scripts/install-shell-from-shebang.sh`</a>: Modified the `install-shell-if-missing()` function to check for missing files and use the `find` command to install all `.sh` files in the current directory and its subdirectories.