### PR TITLE
Update .github/workflows/lint.yml to include ubuntu 24.04 in job matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images
-        ubuntu-release: [ '20.04', '22.04' ]
+        ubuntu-release: [ '20.04', '22.04', '24.04' ]
     runs-on: ubuntu-${{ matrix.ubuntu-release }}
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images
-        ubuntu-release: [ '20.04', '22.04' ]
+        ubuntu-release: [ '20.04', '22.04', '24.04' ]
     runs-on: ubuntu-${{ matrix.ubuntu-release }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,8 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images
-        ubuntu-release: [ '20.04', '22.04', '24.04' ]
-    runs-on: ubuntu-${{ matrix.ubuntu-release }}
+        release: [ 'ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04' ]
+    runs-on: ${{ matrix.ubuntu-release }}
     steps:
       - uses: actions/checkout@v4
       - name: syntax
@@ -54,8 +54,8 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images
-        ubuntu-release: [ '20.04', '22.04', '24.04' ]
-    runs-on: ubuntu-${{ matrix.ubuntu-release }}
+        release: [ 'ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04' ]
+    runs-on: ${{ matrix.release }}
     steps:
       - uses: actions/checkout@v4
       - name: syntax


### PR DESCRIPTION
Update `.github/workflows/lint.yml` to include Ubuntu 24.04 in the job matrix

* Add '24.04' to the `ubuntu-release` matrix for the `sh-verify-examples` job
* Add '24.04' to the `ubuntu-release` matrix for the `sh-verify-all` job
