### PR TITLE
Update actions/checkout to use SHA hash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       md-changed-files:  ${{ steps.changed-files-md.outputs.all_changed_files }}
       md-any-changed:    ${{ steps.changed-files-md.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
         ubuntu-release: [ '20.04', '22.04' ]
     runs-on: ubuntu-${{ matrix.ubuntu-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: syntax
         uses: ./
         with:
@@ -57,7 +57,7 @@ jobs:
         ubuntu-release: [ '20.04', '22.04' ]
     runs-on: ubuntu-${{ matrix.ubuntu-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: syntax
         uses: ./
         with:
@@ -68,7 +68,7 @@ jobs:
     if:    needs.list-files.outputs.sh-any-changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check syntax
         uses: ./
         with:
@@ -82,7 +82,7 @@ jobs:
     if:   needs.list-files.outputs.md-any-changed == 'true'
     needs: list-files
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -11,7 +11,7 @@ jobs:
   tag-major:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Update major version tag
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
@@ -31,7 +31,7 @@ jobs:
   tag-majorminor:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Update major/minor version tag
       run: |
         VERSION=${GITHUB_REF#refs/tags/}

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Or you can install all "missing" shells in a single command
 ### Simple install (check all files named .sh)
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@b3b4b1a
 - uses: Klintrup/simple-shell-syntax-check@v2
 ```
 
 ### Install fish before running action
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@b3b4b1a
 - run: sudo apt-get install -y fish
 - uses: Klintrup/simple-shell-syntax-check@v2
 ```
@@ -73,7 +73,7 @@ Or you can install all "missing" shells in a single command
 ### Only validate files if changed (for pull request)
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@b3b4b1a
   with:
     ref: ${{ github.head_ref }}
     fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Or you can install all "missing" shells in a single command
 ### Simple install (check all files named .sh)
 
 ```yaml
-- uses: actions/checkout@b3b4b1a
+- uses: actions/checkout@v4
 - uses: Klintrup/simple-shell-syntax-check@v2
 ```
 
 ### Install fish before running action
 
 ```yaml
-- uses: actions/checkout@b3b4b1a
+- uses: actions/checkout@v4
 - run: sudo apt-get install -y fish
 - uses: Klintrup/simple-shell-syntax-check@v2
 ```
@@ -73,7 +73,7 @@ Or you can install all "missing" shells in a single command
 ### Only validate files if changed (for pull request)
 
 ```yaml
-- uses: actions/checkout@b3b4b1a
+- uses: actions/checkout@v4
   with:
     ref: ${{ github.head_ref }}
     fetch-depth: 0


### PR DESCRIPTION
Update `actions/checkout` to use SHA hash instead of version tag in workflows and README.

* **README.md**
  - Update `actions/checkout` to use SHA hash `b3b4b1a` instead of `v4`.

* **.github/workflows/lint.yml**
  - Update `actions/checkout` to use SHA hash `11bd71901bbe5b1630ceea73d27597364c9af683` instead of `v4`.
  - Add comment for `v4.2.2` to specify what version it specifies.

* **.github/workflows/tags.yml**
  - Update `actions/checkout` to use SHA hash `11bd71901bbe5b1630ceea73d27597364c9af683` instead of `v4`.
  - Add comment for `v4.2.2` to specify what version it specifies.

