### PR TITLE
Refactor SonarQube permissions and enable project name in configuration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Override default repository permissions to restrict access
 permissions: {}
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,24 +5,26 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-permissions: 
-  contents: read # Required for SonarQube to read the code
-  issues: write # Required for SonarQube to create issues
-  pull-requests: write # Required for SonarQube to create PR comments
-  security-events: write # Required for SonarQube to upload SARIF results
-  actions: read # Required for SonarQube to get the Action run status
-  checks: write # Required for SonarQube to create checks
-  statuses: write # Required for SonarQube to create statuses
-  deployments: write # Required for SonarQube to create deployments
+
+permissions: {}
 
 jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for SonarQube to read the code
+      issues: write # Required for SonarQube to create issues
+      pull-requests: write # Required for SonarQube to create PR comments
+      security-events: write # Required for SonarQube to upload SARIF results
+      actions: read # Required for SonarQube to get the Action run status
+      checks: write # Required for SonarQube to create checks
+      statuses: write # Required for SonarQube to create statuses
+      deployments: write # Required for SonarQube to create deployments
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=klintrup
 
 
 # This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=simple-shell-syntax-check
+sonar.projectName=simple-shell-syntax-check
 #sonar.projectVersion=1.0
 
 


### PR DESCRIPTION
This pull request introduces updates to the SonarCloud workflow configuration and the `sonar-project.properties` file to enhance clarity and functionality. The most significant changes involve restructuring the workflow file and enabling the `sonar.projectName` property.

### Workflow configuration updates:

* [`.github/workflows/sonarcloud.yml`](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR8-R14): Added a `permissions: {}` block at the top level of the workflow file to explicitly define default permissions for the workflow.

### SonarCloud project properties:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL6-R6): Uncommented the `sonar.projectName` property to ensure the project name is displayed in the SonarCloud UI.